### PR TITLE
Implement K-DHT for `spartan-farmer`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3213,12 +3213,14 @@ dependencies = [
  "async-io",
  "futures 0.3.17",
  "futures-timer 3.0.2",
+ "if-addrs",
  "if-watch",
  "ipnet",
  "libc",
  "libp2p-core",
  "log",
  "socket2 0.4.1",
+ "tokio",
 ]
 
 [[package]]
@@ -7358,6 +7360,7 @@ dependencies = [
  "hex",
  "indicatif",
  "jsonrpsee",
+ "libp2p",
  "log",
  "rand 0.8.4",
  "rayon",

--- a/crates/spartan-farmer/Cargo.toml
+++ b/crates/spartan-farmer/Cargo.toml
@@ -48,6 +48,11 @@ version = "0.16.0"
 features = ["derive"]
 version = "1.0.125"
 
+[dependencies.libp2p]
+version = "0.39.1"
+features = [ "noise", "mplex", "kad", "tcp-tokio" ]
+default-features = false
+
 [dev-dependencies]
 rand = "0.8.3"
 

--- a/crates/spartan-farmer/src/commands.rs
+++ b/crates/spartan-farmer/src/commands.rs
@@ -1,3 +1,4 @@
+pub mod dht;
 mod farm;
 mod plot;
 

--- a/crates/spartan-farmer/src/commands/dht.rs
+++ b/crates/spartan-farmer/src/commands/dht.rs
@@ -1,0 +1,8 @@
+// The Client API which the end-user is supposed to interact with.
+pub mod client;
+// Core libp2p activities like defining network behaviour and events, bootstrap-ing,
+// creating of swarm and such...
+mod core;
+// EventLoop which actually processes libp2p SwarmEvents. The Client API interacts with the
+// EventLoop to transfer and receieve data.
+mod eventloop;

--- a/crates/spartan-farmer/src/commands/dht.rs
+++ b/crates/spartan-farmer/src/commands/dht.rs
@@ -1,3 +1,21 @@
+// Stuff for Kademlia
+use libp2p::kad::{record::store::MemoryStore, Kademlia, KademliaEvent};
+
+// Stuff for defining composed behaviour
+use libp2p::NetworkBehaviour;
+
+// Stuff needed to create the swarm
+use libp2p::core::{upgrade, Transport};
+use libp2p::identity;
+use libp2p::mplex;
+use libp2p::noise::{Keypair, NoiseConfig, X25519Spec};
+use libp2p::swarm::SwarmBuilder;
+use libp2p::tcp::TokioTcpConfig;
+use libp2p::{PeerId, Swarm};
+
+// Stuff needed to set up channels between Client API task and EventLoop task.
+use tokio::sync::mpsc::{channel, Receiver, Sender};
+
 // The Client API which the end-user is supposed to interact with.
 pub mod client;
 // Core libp2p activities like defining network behaviour and events, bootstrap-ing,

--- a/crates/spartan-farmer/src/commands/dht/client.rs
+++ b/crates/spartan-farmer/src/commands/dht/client.rs
@@ -1,0 +1,31 @@
+use super::core::{create_swarm, ComposedEvent};
+use super::eventloop::EventLoop;
+use super::*;
+
+pub enum ClientEvent {
+    StartListening,
+    Dial,
+    Provide,
+    Find,
+}
+
+pub struct Client {
+    network_rx: Receiver<ComposedEvent>,
+    client_tx: Sender<ClientEvent>,
+}
+
+impl Client {
+    /// This method will construct a new Swarm and eventloop.
+    pub async fn new() -> (Self, EventLoop) {
+        let (network_tx, network_rx) = channel(10);
+        let (client_tx, client_rx) = channel(10);
+
+        return (
+            Client {
+                network_rx,
+                client_tx,
+            },
+            EventLoop::new(create_swarm().await, client_rx, network_tx)
+        );
+    }
+}

--- a/crates/spartan-farmer/src/commands/dht/client.rs
+++ b/crates/spartan-farmer/src/commands/dht/client.rs
@@ -14,18 +14,24 @@ pub struct Client {
     client_tx: Sender<ClientEvent>,
 }
 
+pub async fn dht_listener() -> (Client, EventLoop) {
+    let (network_tx, network_rx) = channel(10);
+    let (client_tx, client_rx) = channel(10);
+
+    return (
+        Client::new(network_rx, client_tx),
+        EventLoop::new(create_swarm().await, client_rx, network_tx),
+    );
+}
+
 impl Client {
     /// This method will construct a new Swarm and eventloop.
-    pub async fn new() -> (Self, EventLoop) {
-        let (network_tx, network_rx) = channel(10);
-        let (client_tx, client_rx) = channel(10);
-
-        return (
-            Client {
-                network_rx,
-                client_tx,
-            },
-            EventLoop::new(create_swarm().await, client_rx, network_tx)
-        );
+    pub fn new(network_rx: Receiver<ComposedEvent>, client_tx: Sender<ClientEvent>) -> Self {
+        Client {
+            network_rx,
+            client_tx,
+        }
+    }
+    pub fn start_listening(&mut self) {
     }
 }

--- a/crates/spartan-farmer/src/commands/dht/core.rs
+++ b/crates/spartan-farmer/src/commands/dht/core.rs
@@ -1,0 +1,18 @@
+// Pull imports from the parent module
+use super::*;
+
+#[derive(NetworkBehaviour)]
+#[behaviour(event_process = false, out_event = "ComposedEvent")]
+pub struct ComposedBehaviour {
+    kademlia: Kademlia<MemoryStore>,
+}
+
+pub enum ComposedEvent {
+    Kademlia(KademliaEvent),
+}
+
+impl From<KademliaEvent> for ComposedEvent {
+    fn from(event: KademliaEvent) -> Self {
+        ComposedEvent::Kademlia(event)
+    }
+}

--- a/crates/spartan-farmer/src/commands/dht/core.rs
+++ b/crates/spartan-farmer/src/commands/dht/core.rs
@@ -16,3 +16,29 @@ impl From<KademliaEvent> for ComposedEvent {
         ComposedEvent::Kademlia(event)
     }
 }
+
+pub async fn create_swarm() -> Swarm<ComposedBehaviour> {
+    // Generate IDs.
+    let key = identity::Keypair::generate_ed25519();
+    let peerid = PeerId::from_public_key(key.public());
+
+    // Generate NOISE authentication keys.
+    let auth_keys = Keypair::<X25519Spec>::new().into_authentic(&key).unwrap();
+
+    // Create secure-TCP transport that uses tokio under the hood.
+    let transport = TokioTcpConfig::new()
+        .upgrade(upgrade::Version::V1)
+        .authenticate(NoiseConfig::xx(auth_keys).into_authenticated())
+        .multiplex(mplex::MplexConfig::new())
+        .boxed();
+
+    let behaviour = ComposedBehaviour {
+        kademlia: Kademlia::new(peerid.clone(), MemoryStore::new(peerid.clone())),
+    };
+
+    SwarmBuilder::new(transport, behaviour, peerid.clone())
+        .executor(Box::new(|fut| {
+            tokio::spawn(fut);
+        }))
+        .build()
+}

--- a/crates/spartan-farmer/src/commands/dht/eventloop.rs
+++ b/crates/spartan-farmer/src/commands/dht/eventloop.rs
@@ -1,0 +1,26 @@
+use super::client::ClientEvent;
+use super::core::{ComposedBehaviour, ComposedEvent};
+use super::*;
+
+pub struct EventLoop {
+    swarm: Swarm<ComposedBehaviour>,
+    client_rx: Receiver<ClientEvent>,
+    network_tx: Sender<ComposedEvent>,
+}
+
+impl EventLoop {
+    /// Create new event loop
+    pub fn new(
+        swarm: Swarm<ComposedBehaviour>,
+        client_rx: Receiver<ClientEvent>,
+        network_tx: Sender<ComposedEvent>,
+    ) -> Self {
+        EventLoop {
+            swarm,
+            client_rx,
+            network_tx,
+        }
+    }
+    /// Run event loop. We will use this method to spawn the event loop in a background task.
+    pub async fn run(&mut self) {}
+}


### PR DESCRIPTION
This PR creates a submodule `dht` in the `commands` module, that behaves as a wrapper around `rust-libp2p`.

The `dht` module is logically divided into two sections:
1. `Client` API - these are the methods that we will be using inside `spartan-farmer` to interact with the DHT.
2. `EventLoop` - this is the part of code that handles the actual network events from the Kademlia protocol.

The `EventLoop` is spawned as a background task, so that it works in an async manner.

Design patterns used here were picked up from the following PR in `rust-libp2p`:
1. [PR 2186](https://github.com/libp2p/rust-libp2p/pull/2186)

To-do:
1. Add support for `bootstrap`.
2. Add `Result` to method return values.